### PR TITLE
Afghan afghani has now correct 3 letter currency code AFN

### DIFF
--- a/data/countryCurrencyMetadata.csv
+++ b/data/countryCurrencyMetadata.csv
@@ -1,5 +1,5 @@
 ﻿country,currencyName,currencyCode
-Afghanistan,Afghan afghani,afghani 
+Afghanistan,Afghan afghani,AFN 
 Akrotiri and Dhekelia,European euro,EUR
 Aland Islands,European euro,EUR
 Albania,Albanian lek,ALL


### PR DESCRIPTION
Afghan afghani currency code was afgani, not AFN